### PR TITLE
Fix: qrshot check deps.

### DIFF
--- a/qrshot
+++ b/qrshot
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
 ############################################################################
-# Depends for run: zbarimg, qrencode, scrot
+# Depends for run: zbarimg(from zbar-tools), qrencode, scrot
 ############################################################################
 
 
 # Check depends
 for check in 'zbarimg' 'qrencode' 'scrot'; do
-    if ! type -P "$check" 1 >/dev/null 2>/dev/null; then
+    if ! type -P "$check" &> /dev/null; then
         echo "Please install $check"
         exit 1
     fi


### PR DESCRIPTION
- O zbarimg está dentro do pacote zbar-tools no [debian12](https://packages.debian.org/search?suite=bullseye&arch=any&mode=exactfilename&searchon=contents&keywords=zbarimg) e pode ajudar quem vier a precisar localizar
- Havia um espaço na checagem das dependências que impedia seguir com o script. Atualizei para &> /dev/null
